### PR TITLE
jdblend Optimisation - Move vinv out of Frame Eval

### DIFF
--- a/jvsfunc.py
+++ b/jvsfunc.py
@@ -190,7 +190,7 @@ def jdeblend(src_fm, src, vinverse=True):
     clist = [src_fm, inter0, inter1, inter2, inter3, inter4, src, src_fm[0]+src_fm[:-1]]
     out = core.std.FrameEval(src_fm, partial(calculate, src=clist[:6]), [core.std.PlaneStats(i) for i in clist])
     if vinverse:
-        out = core.std.FrameEval(out, partial(vinv_combed_func, original=out, vinversed=core.vinverse.Vinverse(out)))
+        out = core.std.FrameEval(out, partial(vinv_combed_func, original=out, vinversed=core.vinverse.Vinverse(out)), src_fm)
     
     return out
 

--- a/jvsfunc.py
+++ b/jvsfunc.py
@@ -179,11 +179,20 @@ def jdeblend(src_fm, src, vinverse=True):
         src, out = src[1:], src[0]
         if comb[0] == 1:
             out = src[avg.index([i for i in avg if i != ref][0])]
-            out = out.vinverse.Vinverse() if vinverse else out
         return out[n+1] if sum(comb) == 2 else out
+
+    def vinv_combed_func(n, f, original, vinversed):
+        if f.props['_Combed']:
+            return vinversed
+        else:
+            return original
        
     clist = [src_fm, inter0, inter1, inter2, inter3, inter4, src, src_fm[0]+src_fm[:-1]]
-    return core.std.FrameEval(src_fm, partial(calculate, src=clist[:6]), [core.std.PlaneStats(i) for i in clist])
+    out = core.std.FrameEval(src_fm, partial(calculate, src=clist[:6]), [core.std.PlaneStats(i) for i in clist])
+    if vinverse:
+        out = core.std.FrameEval(out, partial(vinv_combed_func, original=out, vinversed=core.vinverse.Vinverse(out)))
+    
+    return out
 
 def jdeblend_kf(src, src_fm):
     """


### PR DESCRIPTION
See comments on the first commit for more description on changes made, not that there is many. Also note again that this is entirely untested and written only with syntax highlighting, so there's probably an error somewhere.

This is certainly doable within just one Frame Eval as well, though whether it would actually be worth doing, I'm not sure (1 extra branch within the original, vs 1 more Frame Eval can't be that different really).

There other changes that I would also like to make, however until I have access to a proper work environment where I can ensure code at least runs, I will not be submitting these. Let me know if there's anything else you'd like me to look at.